### PR TITLE
#13 Upgrade to Fastparse 0.3.6 to fix bug with infinite loop

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ scalacOptions ++=  Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.lihaoyi" %% "fastparse" % "0.3.5",
+  "com.lihaoyi" %% "fastparse" % "0.3.6",
   "ch.qos.logback" % "logback-classic" % "1.1.2",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 )

--- a/src/test/scala/com/github/jeroenr/gnip/rule/validation/GnipRuleValidatorSpec.scala
+++ b/src/test/scala/com/github/jeroenr/gnip/rule/validation/GnipRuleValidatorSpec.scala
@@ -161,6 +161,9 @@ class GnipRuleValidatorSpec extends WordSpec with MustMatchers with TryValues {
     "NOT accept unclosed groups" in {
       GnipRuleValidator("(hello (world) bla", "twitter").failure
     }
+    "NOT accept deep unclosed groups" in {
+      GnipRuleValidator("(ab ( cd ( ef( gh ( ij ((hello (world) bla) lol) hehe))) xz)", "twitter").failure
+    }
     "accept single powertrack operator" in {
       GnipRuleValidator("lang:EN", "twitter").success
     }


### PR DESCRIPTION
My PR for the infinite loop fix in Fastparse was merged and released so we upgrade to the latest Fastparse to fix it.
